### PR TITLE
Udev rules

### DIFF
--- a/91-g13.rules
+++ b/91-g13.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c21c", MODE="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c21c", MODE="0660", GROUP="g13"

--- a/91-g13.rules
+++ b/91-g13.rules
@@ -1,1 +1,2 @@
-SUBSYSTEM=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c21c", MODE="0660", GROUP="g13"
+SUBSYSTEM=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c21c", MODE="0660", GROUP="usb"
+KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="usb"

--- a/91-g13.rules
+++ b/91-g13.rules
@@ -1,2 +1,0 @@
-SUBSYSTEM=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c21c", MODE="0660", GROUP="usb"
-KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="usb"

--- a/91-g13.rules.tmpl
+++ b/91-g13.rules.tmpl
@@ -1,0 +1,2 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c21c", MODE="0660", GROUP="!!GROUP!!"
+KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="!!GROUP!!"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GROUP='usb'
-PREFIX='/usr/local/g13-userspace'
+PREFIX='.'
 
 all: g13d pbm2lpbm 91-g13.rules clock.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,24 @@
-all: g13d pbm2lpbm
+GROUP='usb'
+PREFIX='/usr/local/g13-userspace'
+
+all: g13d pbm2lpbm 91-g13.rules clock.sh
 
 g13d: g13.h g13.cc
 	g++ -o g13d -std=c++0x g13.cc -lusb-1.0
 
 pbm2lpbm: pbm2lpbm.c
 	g++ -o pbm2lpbm pbm2lpbm.c
+
+91-g13.rules: 91-g13.rules.tmpl
+	sed 's/!!GROUP!!/${GROUP}/' 91-g13.rules.tmpl > 91-g13.rules
+
+clock.sh: clock.sh.tmpl
+	sed 's|\!\!PREFIX\!\!|${PREFIX}|' clock.sh.tmpl > clock.sh
+
+install: all
+	install -m 755 -D g13d ${PREFIX}/g13d
+	install -m 755 -D clock.sh ${PREFIX}/g13-clock.sh
+	install -m 755 -D pbm2lpbm ${PREFIX}/pbm2lpbm
 
 package:
 	rm -Rf g13-userspace

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-GROUP='usb'
-PREFIX='.'
+GROUP = 'usb'
+PREFIX = '.'
 
 all: g13d pbm2lpbm 91-g13.rules clock.sh
 
@@ -27,4 +27,4 @@ package:
 	tar cjf g13-userspace.tbz2 g13-userspace
 	rm -Rf g13-userspace
 clean: 
-	rm -f g13 pbm2lpbm
+	rm -f g13 pbm2lpbm clock.sh 91-g13.rules

--- a/README.org
+++ b/README.org
@@ -2,11 +2,40 @@
 ** Installation
 Make sure you have boost and libusb-1.0 installed.
 
+You should also create
+
 Compile by running
 
 > make
 
-If you want to run the daemon as user, put the file 91-g13.rules into /etc/udev/rules.d/ (or whatever directory your distribution uses).
+Note that the default prefix is ".". If you would like make install and 
+the clock shell script to use a different directory (such as /usr/local/bin)
+then use the following:
+
+> PREFIX=/usr/local/bin make
+
+** Install for non-root use
+
+In order to run the g13 deamon as a user, file permissions in /dev
+need to be fixed. In order to do this you should do the following:
+
+1. Create the group: sudo groupadd --system usb
+2. add yourself and any other users who will use g13 to the new group: 
+  sudo usermod -a -G usb USERNAME
+3. copy the file 91-g13.rules into /etc/udev/rules.d/:
+  sudo cp 91-g13.rules /etc/udev/rules.d
+4. run udevadm trigger
+5. run: sudo make install 
+
+If you are logged in as the user, you will need to logout and back in.
+
+If you have problems check that /etc/udev/rules.d is the correct udev rules
+location for your distribution.
+
+If you would like to change the name of the group used, then use the following
+option with make to change it:
+
+> GROUP='newgroup' make 
 
 ** Running
 Connect your device, then run ./g13, it should automatically find your device.

--- a/README.org
+++ b/README.org
@@ -33,8 +33,9 @@ If you have problems check that /etc/udev/rules.d is the correct udev rules
 location for your distribution.
 
 If you would like to change the name of the group used, then use the following
-option with make to change it:
+option with make to change it: 
 
+> make clean
 > GROUP='newgroup' make 
 
 ** Running

--- a/README.org
+++ b/README.org
@@ -12,7 +12,7 @@ Note that the default prefix is ".". If you would like make install and
 the clock shell script to use a different directory (such as /usr/local/bin)
 then use the following:
 
-> PREFIX=/usr/local/bin make
+> make PREFIX=/usr/local/bin 
 
 ** Install for non-root use
 
@@ -25,7 +25,7 @@ need to be fixed. In order to do this you should do the following:
 3. copy the file 91-g13.rules into /etc/udev/rules.d/:
   sudo cp 91-g13.rules /etc/udev/rules.d
 4. run udevadm trigger
-5. run: sudo make install 
+5. run: sudo make PREFIX='/usr/local/bin' install 
 
 If you are logged in as the user, you will need to logout and back in.
 
@@ -36,7 +36,7 @@ If you would like to change the name of the group used, then use the following
 option with make to change it: 
 
 > make clean
-> GROUP='newgroup' make 
+> make GROUP='newgroup'
 
 ** Running
 Connect your device, then run ./g13, it should automatically find your device.

--- a/clock.sh.tmpl
+++ b/clock.sh.tmpl
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+PATH=$PATH:!!PREFIX!!
+export PATH
+
 center_x=30
 center_y=20
 diameter=18
@@ -37,6 +41,6 @@ min_x=$(echo "scale=3;$center_x + $min_orig_y * s($min/60*(2*4*a(1)))" | bc -l)
 min_y=$(echo "scale=3;$center_y - $min_orig_y * c($min/60*(2*4*a(1)))" | bc -l)
 preparams="-size 160x43 xc:white -stroke black -fill white -draw \"circle 30,20 30,2\" -draw \"line 30,20 $sec_x,$sec_y\" -draw \"line 30,20 $min_x,$min_y\" -draw \"line 30,20 $hr_x,$hr_y\" "
 postparams="-pointsize 16 -fill black -font Courier -draw \"text 60,15 '$Date'\" -draw \"text 68,35 '$Time'\" pbm:- "
-eval convert $preparams $ticks $postparams | ./pbm2lpbm > /tmp/g13-0
+eval convert $preparams $ticks $postparams | pbm2lpbm > /tmp/g13-0
 sleep 1
 done


### PR DESCRIPTION
I just setup my G13 using this and found the userspace setup lacking.

The changes on this branch update the udev rules to allow for better device control using a
group, and update the instructions on how to set it up.

I also added a couple of makefile targets for install and filling in values to make clock.sh and udev rules templates so users can choose what group and install prefix they want. 