### PR TITLE
Bugfix: don't forget return values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,4 @@ package:
 	tar cjf g13-userspace.tbz2 g13-userspace
 	rm -Rf g13-userspace
 clean: 
-	rm -f g13 pbm2lpbm
+	rm -f g13d pbm2lpbm *.o

--- a/g13.cc
+++ b/g13.cc
@@ -788,6 +788,8 @@ int G13_Manager::run() {
 			}
 	} while (running);
 	cleanup();
+        
+        return 0;
 }
 } // namespace G13
 

--- a/g13_main.cc
+++ b/g13_main.cc
@@ -65,6 +65,6 @@ int main(int argc, char *argv[]) {
 		manager.set_log_level( manager.string_config_value( "log_level") );
 	}
 
-	manager.run();
+	return manager.run();
 }
 

--- a/helper.hpp
+++ b/helper.hpp
@@ -168,7 +168,7 @@ struct _map_keys_out {
 
 
 template <class STREAM_T, class MAP_T>
-STREAM_T &operator <<( STREAM_T &o, const _map_keys_out<MAP_T> &_mko ) {
+STREAM_T& operator <<( STREAM_T &o, const _map_keys_out<MAP_T> &_mko ) {
 	bool first = true;
 	for( auto i = _mko.container.begin(); i != _mko.container.end(); i++ ) {
 		if( first ) {
@@ -178,6 +178,7 @@ STREAM_T &operator <<( STREAM_T &o, const _map_keys_out<MAP_T> &_mko ) {
 			o << _mko.sep << i->first;
 		}
 	}
+	return o;
 };
 
 template <class MAP_T>


### PR DESCRIPTION
Fixes a SIGABRT:

```
[2018-06-15 20:11:50.299473] [0x00007ffff7fa6080] [info]    set log level to info
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<std::logic_error> >'
  what():  character conversion failed

Program received signal SIGABRT, Aborted.
```