### PR TITLE
Add mouse buttons as MLEFT MRIGHT etc.

### DIFF
--- a/g13.cc
+++ b/g13.cc
@@ -157,6 +157,10 @@ int g13_create_uinput(G13_Device *g13) {
 	 ioctl(ufile, UI_SET_RELBIT, REL_Y);*/
 	for (int i = 0; i < 256; i++)
 		ioctl(ufile, UI_SET_KEYBIT, i);
+	//Mouse buttons
+	for (int i = 0x110; i < 0x118; i++)
+		ioctl(ufile, UI_SET_KEYBIT, i);
+
 	ioctl(ufile, UI_SET_KEYBIT, BTN_THUMB);
 
 	int retcode = write(ufile, &uinp, sizeof(uinp));

--- a/g13_keys.cc
+++ b/g13_keys.cc
@@ -51,6 +51,18 @@ namespace G13 {
 		(LEFT)(RIGHT)(UP)(DOWN)												\
 		(PAGEUP)(PAGEDOWN)(HOME)(END)(INSERT)(DELETE)						\
 
+/*! m_INPUT_BTN_SEQ is a Boost Preprocessor sequence containing the
+ * names of button events we can send through binding actions.
+ * These correspond to BTN_xxx value definitions in <linux/input.h>,
+ * i.e. LEFT is BTN_LEFT, RIGHT is BTN_RIGHT, etc.
+ *
+ * The binding names have prefix M to avoid naming conflicts.
+ * e.g. LEFT keyboard button and LEFT mouse button
+ * i.e. LEFT mouse button is named MLEFT, MIDDLE mouse button is MMIDDLE
+ */
+#define M_INPUT_BTN_SEQ                                                       \
+	(LEFT)(RIGHT)(MIDDLE)(SIDE)(EXTRA)                                  \
+
 
 // *************************************************************************
 
@@ -159,6 +171,18 @@ void G13_Manager::init_keynames() {
 
 
 	BOOST_PP_SEQ_FOR_EACH(ADD_KB_KEY_MAPPING, _, KB_INPUT_KEY_SEQ)
+
+	// setup maps to let us convert between strings and linux button names
+	#define ADD_M_BTN_MAPPING( r, data, elem )								\
+	{																		\
+		std::string name = string("M") + string(BOOST_PP_STRINGIZE(elem));						\
+		int keyval = BOOST_PP_CAT( BTN_, elem );							\
+		input_key_to_name[keyval] = name; 									\
+		input_name_to_key[name] = keyval;									\
+	}																		\
+
+
+	BOOST_PP_SEQ_FOR_EACH(ADD_M_BTN_MAPPING, _, M_INPUT_BTN_SEQ)
 }
 
 LINUX_KEY_VALUE G13_Manager::find_g13_key_value( const std::string &keyname ) const {


### PR DESCRIPTION
Enabled support for mouse buttons "left", "right", "middle", "side" and "extra".
Support for buttons BTN_BACK, BTN_FORWARD and BTN_TASK can be enabled by adding them to M_INPUT_BTN_SEQ.

Because left and right buttons already exists on keyboard, bind names use prefix M.
i.e. use MLEFT for the left mouse button, MRIGHT for the right mouse button.